### PR TITLE
Finding the parent of selector using Child combinator should remove the ">" symbol

### DIFF
--- a/src/__tests__/probe._addSelector.test.js
+++ b/src/__tests__/probe._addSelector.test.js
@@ -47,6 +47,30 @@ describe("_addSelector", () => {
         expect(spy).toBeCalledWith(null, ".aaa", false);
     });
 
+    // ===================================================================================================
+    // strictInferior: {
+    // input: "li > ul, li > ol { margin-bottom: 0; }",
+    // selectors: ["li"]
+    // }
+
+    test("should handle  strict parent selector correctly", () => {
+        var p = new Probe();
+        // p._addSelector = jest.fn();
+        const spy = jest.spyOn(p, "_addSelector");
+        p._extractSelectors("u", ".aaa > .bbb {color:red;}");
+
+        expect(p._allSelectors).toMatchObject({
+            ".aaa > .bbb": {
+                parent: ".aaa"
+            },
+            ".aaa": {
+                parent: null
+            }
+        });
+        expect(spy).toBeCalledWith("u", ".aaa > .bbb", true);
+        expect(spy).toBeCalledWith(null, ".aaa", false);
+    });
+
     test("set the exits value", () => {
         var p = new Probe();
 

--- a/src/__tests__/probe._extractSelectors.test.js
+++ b/src/__tests__/probe._extractSelectors.test.js
@@ -71,7 +71,7 @@ const inputs = {
         input: "@media (max-width:700px){.aaa{max-width:calc(100vw - 50px)}}@-webkit-keyframes slide-in{0%{-webkit-transform:translateX(400px);}}.bbb{margin:8px 0;position:relative}",
         selectors: [".aaa", ".bbb"]
     },
-    // ==
+    // ===================================================================================================
     oKeyframes: {
         input: ".a1{color:red}@-o-keyframes f1{to{opacity:.9}}.a2{color:red2}@-webkit-keyframes f2{0%{opacity:0}to{opacity:1}}.a3{color:red3}@keyframes f3{0%{opacity:1}}.a4{color:red4}@-webkit-keyframes f4{0%{opacity:0}}.a5{color:red5}@keyframes f5{0%{opacity:1}}.a6{display:flex}",
         selectors: [".a1", ".a2", ".a3", ".a4", ".a5", ".a6"]

--- a/src/probe.js
+++ b/src/probe.js
@@ -313,14 +313,16 @@ Probe.prototype._addSelector = function(url, text, existsInStyleSheet) {
 Probe.prototype._findParentSelector = function(selector) {
     // This find parent pattern with space seperated selector
     // @TODO extra suport
-    // child >
     // attribute selector => blob[attribute=value]
     // multiple class selector => .red.square
     //      --> sort them?
     //      --> create a popularity sort?
     for (var i = selector.length; i; i--) {
         if (selector.charAt(i) == " ") {
-            var parent = selector.substr(0, i);
+            var parent = selector.substr(0, i).trim();
+            if (parent.slice(-1) === ">") {
+                parent = parent.slice(0, -1).trim();
+            }
             this._addSelector(null, parent, false);
             return parent;
         }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/Child_selectors

Fix the error
> latest.js:1 Uncaught DOMException: Failed to execute 'querySelector' on 'Document': 'li >' is not a valid selector.

The original selector is `li > a,`. As it is composed of multiple elements, the probe is extracting a parent element, but incorrectly.

A try catch will be added later after more bugs are uncovered :)

 